### PR TITLE
Modify view lifecycle methods so that view gets disposed

### DIFF
--- a/SGTabbedPager/SGTabbedPager.cs
+++ b/SGTabbedPager/SGTabbedPager.cs
@@ -174,7 +174,24 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
+
+            TitleScrollView.Delegate = this;
+            ContentScrollView.Delegate = this;
+
             ReloadData();
+        }
+
+        public override void ViewWillDisappear(bool animated)
+        {
+            base.ViewWillDisappear(animated);
+
+            foreach (var btn in _tabButtons)
+            {
+                btn.RemoveTarget(ReceivedButtonTab, UIControlEvent.TouchUpInside);
+            }
+
+            TitleScrollView.Delegate = null;
+            ContentScrollView.Delegate = null;
         }
 
         public override void ViewWillLayoutSubviews() => Layout();


### PR DESCRIPTION
Some references by delegates and event handlers prevented child views of SGTabbedPager
from getting collected by GC due to cyclical references. These
references are removed now when view disappears and set when the view
appears.