### PR TITLE
"Static" tabbed pager + extra customization

### DIFF
--- a/SGTabbedPager/SGTabbedPager.cs
+++ b/SGTabbedPager/SGTabbedPager.cs
@@ -41,6 +41,8 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
         private UIColor _bottomLineColor;
         private UIColor _titleBackgroundColor = UIColor.White;
         private bool _showOnBottom;
+        private int _tabSpacing = 30;
+        private UIEdgeInsets _tabPadding = UIEdgeInsets.Zero;
 
         /// <summary>
         /// Scroll View for the Pager
@@ -95,6 +97,40 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
             {
                 _showOnBottom = value;
                 AdjustConstraints();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that is used as the spacing between tabs in
+        /// <see cref="T:DK.Ostebaronen.Touch.SGTabbedPager.SGTabbedPager"/>.
+        /// </summary>
+        [Export("TabSpacing"), Browsable(true), DefaultValue(30)]
+        public int TabSpacing
+        {
+            get => _tabSpacing;
+            set
+            {
+                _tabSpacing = value;
+                Layout();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that is used as the padding for tab content in
+        /// <see cref="T:DK.Ostebaronen.Touch.SGTabbedPager.SGTabbedPager"/>.
+        /// </summary>
+        [Export("TabPadding"), Browsable(true)]
+        public UIEdgeInsets TabPadding
+        {
+            get => _tabPadding;
+            set
+            {
+                _tabPadding = value;
+                foreach (var button in _tabButtons)
+                {
+                    button.ContentEdgeInsets = _tabPadding;
+                }
+                Layout();
             }
         }
 
@@ -417,15 +453,20 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
                             CGAffineTransform.MakeScale(-1.0f, 1.0f);
                     }
 
+                    button.ContentEdgeInsets = _tabPadding;
                     SizeButtonToFit(button, title, font, selectedFont);
 
-                    var imageSize = image.Size.Width;
-                    var textSize = new NSString(title).StringSize(font).Width;
-                    var width = textSize + imageSize + IconSpacing;
-                    button.Frame = new CGRect(0, 0, width, button.Frame.Height);
+                    if (_tabPadding == UIEdgeInsets.Zero)
+                    {
+                        var imageSize = image.Size.Width;
+                        var textSize = new NSString(title).StringSize(font).Width;
+                        var width = textSize + imageSize + IconSpacing;
+                        button.Frame = new CGRect(0, 0, width, button.Frame.Height);
+                    }
                 }
                 else
                 {
+                    button.ContentEdgeInsets = _tabPadding;
                     SizeButtonToFit(button, title, font, selectedFont);
                 }
 
@@ -487,10 +528,11 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
                     currentX +=
                         (size.Width - label.Frame.Size.Width) / 2f + label.Frame.Size.Width;
                 else
-                    currentX += label.Frame.Size.Width + 30;
+                    currentX += label.Frame.Size.Width + _tabSpacing;
                 var vc = _viewControllers[i];
                 vc.View.Frame = new CGRect(size.Width * i, 0, size.Width, size.Height);
             }
+
             TitleScrollView.ContentSize = new CGSize(currentX, _tabHeight);
             ContentScrollView.ContentSize = new CGSize(size.Width * _viewControllerCount, size.Height);
             _bottomLine.Frame = new CGRect(0, _tabHeight - 1, TitleScrollView.ContentSize.Width, 1);

--- a/SGTabbedPager/SGTabbedPager.cs
+++ b/SGTabbedPager/SGTabbedPager.cs
@@ -90,7 +90,7 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
         [Export("ShowOnBottom"), Browsable(true)]
         public bool ShowOnBottom
         {
-            get { return _showOnBottom; }
+            get => _showOnBottom;
             set
             {
                 _showOnBottom = value;
@@ -117,7 +117,7 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
         [Export("TabColor"), Browsable(true)]
         public UIColor TabColor
         {
-            get { return _tabColor; }
+            get => _tabColor;
             set
             {
                 _tabColor = value;
@@ -132,7 +132,7 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
         [Export("TitleBackgroundColor"), Browsable(true)]
         public UIColor TitleBackgroundColor
         {
-            get { return _titleBackgroundColor; }
+            get => _titleBackgroundColor;
             set
             {
                 _titleBackgroundColor = value;
@@ -161,7 +161,7 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
         [Export("BottomLineColor"), Browsable(true)]
         public UIColor BottomLineColor
         {
-            get { return _bottomLineColor; }
+            get => _bottomLineColor;
             set
             {
                 _bottomLineColor = value;
@@ -444,16 +444,14 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
                 var first = new NSString(title).StringSize(normalFont).Width;
                 var second = new NSString(title).StringSize(selectedFont).Width;
 
-                if (first > second)
-                    button.Font = normalFont;
-                else
-                    button.Font = selectedFont;
-
+                button.Font = first > second ? normalFont : selectedFont;
+                button.TitleLabel.AdjustsFontSizeToFitWidth = false;
+                button.TitleLabel.LineBreakMode = UILineBreakMode.TailTruncation;
                 button.SizeToFit();
 
                 button.Font = currentFont;
-            } 
-            else 
+            }
+            else
             {
                 button.SizeToFit();
             }
@@ -461,8 +459,7 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
 
         private void ReceivedButtonTab(object sender, EventArgs e)
         {
-            var button = sender as UIButton;
-            if (button == null) return;
+            if (!(sender is UIButton button)) return;
 
             var index = _tabButtons.IndexOf(button);
             SwitchPage(index, true);
@@ -475,8 +472,7 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
         {
             var size = View.Bounds.Size;
             TitleScrollView.Frame = new CGRect(0, 0, size.Width, _tabHeight);
-            ContentScrollView.Frame = new CGRect(0, _tabHeight, View.Bounds.Size.Width,
-                View.Bounds.Size.Height - _tabHeight);
+            ContentScrollView.Frame = new CGRect(0, _tabHeight, size.Width, size.Height - _tabHeight);
 
             nfloat currentX = 0f;
             size = ContentScrollView.Frame.Size;


### PR DESCRIPTION
I have an app where I wanted to use the tabbed pager as an unscrollable version that had tabs of equal width that filled the view. However, that was not possible and I did not want to break the visual style of the app as I was using this tabbed pager elsewhere in the app. The alternatives for Xamarin.iOS didn't seem good enough.

As a result, I added the option to make the tabbed pager static as in the tab bar cannot be scrolled and the tabs are made to fit inside the view and fill it. Naturally, this limits the amount of tabs one can have with the static version but not using too many tabs is up to the user. If the text does fit inside the tab, it is truncated and the user can choose to decrease the font size.

I also made it possible to change the spacing between the tabs and to add padding to the tabs as I wanted to have some extra customization options instead of simply setting the spacing for the static version to zero. 

I think this is what people in #6 also wanted.