### PR TITLE
Re-enable parallax animation when switching page unanimated.

### DIFF
--- a/SGTabbedPager/SGTabbedPager.cs
+++ b/SGTabbedPager/SGTabbedPager.cs
@@ -417,7 +417,7 @@ namespace DK.Ostebaronen.Touch.SGTabbedPager
                 ContentScrollView.Frame.Size.Width, ContentScrollView.Frame.Size.Height);
             if (frame.X >= ContentScrollView.ContentSize.Width) return;
 
-            _enableParallax = animated && !_staticTabBar;
+            _enableParallax = !animated && !_staticTabBar;
 
             if (!_staticTabBar)
             {


### PR DESCRIPTION
Hi again. I noticed I inadvertently caused a minor bug that causes the parallax animation to not work when it should. 

When opening a view using the pager and switching tabs by scrolling the content, the tab scroll view does not scroll along and stays in the same position. Touching the tabs re-enables the correct behaviour. This might only happen after calling SwitchPage for the view with the animated flag set to false.

I changed the condition for enabling/disabling parallax back to `!animated`, which it was before my previous changes. I thought the `!` wasn't intentional which made me remove it. This commit restores it.
